### PR TITLE
Manual fixes for PR #12642:

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -112,6 +112,7 @@ function skip_if_remote() {
 
 ###############################################################################
 # BEGIN differences in error messages between buildah and podman
+
 errmsg "non-directory/Dockerfile: not a directory" \
        "Error: context must be a directory:" \
        "bud with a path to a Dockerfile (-f) containing a non-directory entry"
@@ -177,7 +178,8 @@ skip_if_remote "--runtime not meaningful under podman-remote" \
 skip_if_remote "secret files not implemented under podman-remote" \
                "bud with containerfile secret" \
                "bud with containerfile secret accessed on second RUN" \
-               "bud with containerfile secret options"
+               "bud with containerfile secret options" \
+               "bud with containerfile env secret"
 
 skip_if_remote "volumes don't work with podman-remote" \
                "buildah bud --volume" \
@@ -188,18 +190,24 @@ skip_if_remote "--stdin option will not be implemented in podman-remote" \
                "bud test no --stdin"
 
 ###############################################################################
-# BEGIN tests which are skipped due to actual podman-remote bugs.
+# BEGIN tests which are skipped due to actual podman or podman-remote bugs.
 
-###############################################################################
-# BEGIN emergency handling of github git-protocol shutdown
-#
-# Please remove this as soon as we vendor buildah with #3701
+skip "FIXME FIXME FIXME: either fix in this PR, or file new issues" \
+     "build --unsetenv PATH" \
+     "bud-multiple-platform-no-run"
 
-skip "emergency workaround until buildah #3701 gets vendored in" \
-     "bud-git-context" \
-     "bud using gitrepo and branch"
+skip_if_remote "Podman #12838: different error messages" \
+               "bud with .dockerignore #2"
 
-# END   emergency handling of github git-protocol shutdown
+# These two tests, new in 2022-01, invoke podman (create, export) in ways
+# that don't work with podman-remote due to the use of --registries-conf
+skip_if_remote "FIXME FIXME FIXME: find a way to clean up their podman calls" \
+               "bud with run should not leave mounts behind cleanup test" \
+               "bud with custom files in /run/ should persist cleanup test"
+
+skip_if_remote "Do envariables work with -remote? Please look into this." \
+               "build proxy"
+
 ###############################################################################
 # Done.
 

--- a/test/buildah-bud/buildah-tests.diff
+++ b/test/buildah-bud/buildah-tests.diff
@@ -1,15 +1,15 @@
-From 522a0a799bbe5e5ddd4b92507e30ea47b93252f4 Mon Sep 17 00:00:00 2001
+From c18638abfbc1066442cf6ff0b3f012a5c25a918e Mon Sep 17 00:00:00 2001
 From: Ed Santiago <santiago@redhat.com>
 Date: Tue, 9 Feb 2021 17:28:05 -0700
 Subject: [PATCH] tweaks for running buildah tests under podman
 
 Signed-off-by: Ed Santiago <santiago@redhat.com>
 ---
- tests/helpers.bash | 71 +++++++++++++++++++++++++++++++++++++++++++---
- 1 file changed, 67 insertions(+), 4 deletions(-)
+ tests/helpers.bash | 72 +++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 68 insertions(+), 4 deletions(-)
 
 diff --git a/tests/helpers.bash b/tests/helpers.bash
-index bd2794c9..c337a1d5 100644
+index bd2794c9..ecf6ed7d 100644
 --- a/tests/helpers.bash
 +++ b/tests/helpers.bash
 @@ -43,6 +43,23 @@ EOF
@@ -64,7 +64,7 @@ index bd2794c9..c337a1d5 100644
  }
  
  #################
-@@ -192,15 +221,40 @@ function run_buildah() {
+@@ -192,15 +221,41 @@ function run_buildah() {
          --retry)         retry=3;        shift;;  # retry network flakes
      esac
  
@@ -86,9 +86,10 @@ index bd2794c9..c337a1d5 100644
 +            _opts=
 +        fi
 +
-+        # podman always exits 125 where buildah exits 1 or 2
++        # podman always exits 125 where buildah exits 1 or 2 (or, in the
++        # case of git, 128, which is a bug in git, but I won't harp on that).
 +        case $expected_rc in
-+            1|2)   expected_rc=125 ;;
++            1|2|128)   expected_rc=125 ;;
 +        esac
 +    fi
 +    local cmd_basename=$(basename ${podman_or_buildah})
@@ -108,7 +109,7 @@ index bd2794c9..c337a1d5 100644
          # without "quotes", multiple lines are glommed together into one
          if [ -n "$output" ]; then
              echo "$output"
-@@ -499,6 +553,15 @@ function skip_if_no_docker() {
+@@ -499,6 +554,15 @@ function skip_if_no_docker() {
    fi
  }
  


### PR DESCRIPTION
 - reenable git:// tests
 - git command fails with (EVIL) status 128. Deal with it.
 - skip two failing tests that I don't know how to fix:
   a) --unsetenv is not passed on to buildah (should be easy)
   b) something manifest-related

Signed-off-by: Ed Santiago <santiago@redhat.com>